### PR TITLE
feat: 비교 상품 교체 모달 UI 초기 구현

### DIFF
--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -7,12 +7,12 @@ import Button from './button/Button';
 type Props = {
   children: React.ReactNode;
   buttonText?: string;
-  containerStyle?: CSSProperties;
+  containerClassName?: string;
   buttonProps?: Omit<React.ComponentProps<typeof Button>, 'children'>;
   onClose: () => void;
 };
 
-function Modal({ children, buttonText, containerStyle, buttonProps, onClose }: Props) {
+function Modal({ children, buttonText, containerClassName, buttonProps, onClose }: Props) {
   const [modalRoot, setModalRoot] = useState<HTMLElement | null>(null);
 
   useEffect(() => {
@@ -34,8 +34,7 @@ function Modal({ children, buttonText, containerStyle, buttonProps, onClose }: P
       <div className="fixed inset-0 bg-[#000000]/70 z-40" />
       <div className="flex justify-center items-center fixed inset-0 z-50">
         <div
-          className="relative flex flex-col bg-black-500 w-[335px] h-auto rounded-xl md:w-[590px] md:rounded-2xl lg:w-[620px]"
-          style={containerStyle}
+          className={`relative flex flex-col bg-black-500 w-[335px] h-auto rounded-xl md:w-[590px] md:rounded-2xl lg:w-[620px] ${containerClassName}`}
         >
           <button
             onClick={onClose}

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -7,10 +7,12 @@ import Button from './button/Button';
 type Props = {
   children: React.ReactNode;
   buttonText?: string;
+  containerStyle?: CSSProperties;
+  buttonProps?: Omit<React.ComponentProps<typeof Button>, 'children'>;
   onClose: () => void;
 };
 
-function Modal({ children, buttonText, onClose }: Props) {
+function Modal({ children, buttonText, containerStyle, buttonProps, onClose }: Props) {
   const [modalRoot, setModalRoot] = useState<HTMLElement | null>(null);
 
   useEffect(() => {
@@ -31,7 +33,10 @@ function Modal({ children, buttonText, onClose }: Props) {
     <>
       <div className="fixed inset-0 bg-[#000000]/70 z-40" />
       <div className="flex justify-center items-center fixed inset-0 z-50">
-        <div className="relative flex flex-col bg-black-500 w-[335px] h-auto rounded-xl md:w-[590px] md:rounded-2xl lg:w-[620px]">
+        <div
+          className="relative flex flex-col bg-black-500 w-[335px] h-auto rounded-xl md:w-[590px] md:rounded-2xl lg:w-[620px]"
+          style={containerStyle}
+        >
           <button
             onClick={onClose}
             className="absolute top-[15px] right-[15px] md:top-5 md:right-5"
@@ -45,7 +50,9 @@ function Modal({ children, buttonText, onClose }: Props) {
           <div className="flex flex-col flex-1 justify-center items-center w-full px-5 pt-5 overflow-hidden md:px-10 md:pt-10">
             <div className="flex-1 w-full">{children}</div>
             {buttonText && (
-              <Button className="w-full mb-5 md:mb-8 mt-5 md:mt-10">{buttonText}</Button>
+              <Button className="w-full mb-5 md:mb-8 mt-5 md:mt-10" {...buttonProps}>
+                {buttonText}
+              </Button>
             )}
           </div>
         </div>

--- a/src/components/ProductReplacementModal.tsx
+++ b/src/components/ProductReplacementModal.tsx
@@ -1,0 +1,63 @@
+import { useEffect, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import Modal from './Modal';
+import { getProductById } from '@/api/products';
+import Button from './button/Button';
+
+type productDetailProps = {
+  productId: number;
+};
+
+function ProductReplace({ productId }: productDetailProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [isTablet, setIsTablet] = useState(false);
+
+  const buttonStyles =
+    'w-full focus:outline-none focus:ring-0 focus:border-2 focus:border-pink focus:text-pink';
+
+  const containerStyle: React.CSSProperties = {
+    width: isTablet ? '500px' : '335px',
+  };
+
+  // 비교 상품 교체 확인 모달이 열리도록 수정 예정입니다.
+  const modalButtonClick = () => {
+    console.log('교체하기');
+  };
+
+  useEffect(() => {
+    const handleResize = () => setIsTablet(window.innerWidth >= 768);
+    handleResize();
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ['productDetail', productId],
+    queryFn: () => getProductById(productId),
+  });
+
+  if (isLoading) return <div>로딩 중...</div>;
+  if (isError) return <div>에러가 발생했습니다.</div>;
+  if (!data) return <div>상품 정보를 불러오지 못했습니다.</div>;
+
+  return (
+    <Modal
+      onClose={() => setIsOpen(false)}
+      buttonText="교체하기"
+      containerStyle={containerStyle}
+      buttonProps={{ onClick: modalButtonClick }}
+    >
+      <div className="font-semibold text-xl text-gray-50 lg:text-2xl mb-[30px] md:mb-10">
+        지금 보신 ‘{data.name}’ <br /> 어떤 상품과 비교할까요?
+      </div>
+      <Button variant="tertiary" className={`${buttonStyles} mb-[10px] md:mb-[15px] lg:mb-5`}>
+        Air Pods 1
+      </Button>
+      <Button variant="tertiary" className={buttonStyles}>
+        Air Pods Max
+      </Button>
+    </Modal>
+  );
+}
+
+export default ProductReplace;

--- a/src/components/ProductReplacementModal.tsx
+++ b/src/components/ProductReplacementModal.tsx
@@ -15,21 +15,10 @@ function ProductReplace({ productId }: productDetailProps) {
   const buttonStyles =
     'w-full focus:outline-none focus:ring-0 focus:border-2 focus:border-pink focus:text-pink';
 
-  const containerStyle: React.CSSProperties = {
-    width: isTablet ? '500px' : '335px',
-  };
-
   // 비교 상품 교체 확인 모달이 열리도록 수정 예정입니다.
   const modalButtonClick = () => {
     console.log('교체하기');
   };
-
-  useEffect(() => {
-    const handleResize = () => setIsTablet(window.innerWidth >= 768);
-    handleResize();
-    window.addEventListener('resize', handleResize);
-    return () => window.removeEventListener('resize', handleResize);
-  }, []);
 
   const { data, isLoading, isError } = useQuery({
     queryKey: ['productDetail', productId],
@@ -42,9 +31,9 @@ function ProductReplace({ productId }: productDetailProps) {
 
   return (
     <Modal
+      containerClassName="w-[335px] md:w-[500px] lg:w-[500px]"
       onClose={() => setIsOpen(false)}
       buttonText="교체하기"
-      containerStyle={containerStyle}
       buttonProps={{ onClick: modalButtonClick }}
     >
       <div className="font-semibold text-xl text-gray-50 lg:text-2xl mb-[30px] md:mb-10">


### PR DESCRIPTION
## 📝 요약

- 교체하기 버튼 클릭 시 비교 상품 교체 확인 모달이 열리도록 수정 예정입니다.
- 버튼 컴포넌트의 Air Pds 1, Air Pods Max는 임시로 넣어놨습니다.(수정 예정입니다.)
- 모달 공통 컴포넌트에 필요한 경우가 있어 containerStyle에서 containerClassName으로 수정해서 prop 추가했습니다.
<br/>

## 🛠️ PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 변수명 변경 등)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

<br/>

## 📷 스크린샷

아래의 사진은 직접 productId 값을 설정해 테스트한 결과물입니다.

1. PC 버전
![스크린샷 2025-05-21 18 23 14](https://github.com/user-attachments/assets/95ece30a-c08d-48b8-9a34-e26b079bbf4f)
2. 태블릿 버전
![스크린샷 2025-05-21 18 23 45](https://github.com/user-attachments/assets/a13e9c04-884b-4a04-8a6c-b9b4d1c26210)
3. 모바일 버전
![스크린샷 2025-05-21 18 23 40](https://github.com/user-attachments/assets/c9a93edb-445a-4843-9c70-093a7737623e)