### PR TITLE
fix: 리뷰에서 사용자 이미지 깨지는 부분 수정

### DIFF
--- a/src/components/products/ProductReview.tsx
+++ b/src/components/products/ProductReview.tsx
@@ -97,7 +97,7 @@ const ProductReview = ({ review, id, order = 'recent' }: reviewProps) => {
       <div className="md:flex md:justify-between">
         <div className="md:mr-[30px] lg:mr-[80px]">
           <div className="flex items-center gap-[10px] mb-4">
-            <div className="w-[36px] h-[36px]">
+            <div className="w-[36px] h-[36px] flex-shrink-0">
               {review.user.image ? (
                 <Image
                   src={review.user.image}


### PR DESCRIPTION
## 📝 요약

- 리뷰에서 사용자 이미지 깨지는 부분 수정

<br/>

## 🛠️ PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 변수명 변경 등)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

<br/>

## 📷 스크린샷

### 전
<img width="180" alt="스크린샷 2025-05-25 오후 9 25 47" src="https://github.com/user-attachments/assets/5e24575e-f3a6-4fe6-a37c-7ade76ecf5cf" />

### 후
<img width="223" alt="스크린샷 2025-05-25 오후 9 26 45" src="https://github.com/user-attachments/assets/090ded48-fb94-4677-a145-950bd7baebb9" />